### PR TITLE
Fix PyYAML import bug

### DIFF
--- a/scripts/generate_cv.py
+++ b/scripts/generate_cv.py
@@ -9,8 +9,6 @@ import sys
 import subprocess
 import shutil
 from pathlib import Path
-import yaml
-
 try:
     import yaml
 except ImportError:


### PR DESCRIPTION
## Summary
- ensure the PyYAML import error handler runs by removing the unconditional import

## Testing
- `npm test --silent`
- `python3 scripts/generate_cv.py` *(fails with helpful message when pyyaml missing)*

------
https://chatgpt.com/codex/tasks/task_e_68421da4270083279f72263efbf8b0ff