### PR TITLE
Update cv.yml paths in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ terraform apply -auto-approve
 ```
 
 ## Editing Content
-All CV data is centralized under `app/src/data/cv.yml`. To update your profile, experience, education, or skills, edit that file and push to `main`—the CI/CD pipeline will rebuild and redeploy your changes.
+All CV data is centralized under `data/cv.yml`. To update your profile, experience, education, or skills, edit that file and push to `main`—the CI/CD pipeline will rebuild and redeploy your changes.
 
 ## Additional Resources
-- Runbook & troubleshooting: [RUNBOOK.md]
+- Runbook & troubleshooting: [RUNBOOK.md](RUNBOOK.md)
 - Security policy: [SECURITY.md]
 
 ## Contributing

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -70,7 +70,7 @@ In your GitHub repo under **Settings > Secrets > Actions**, add:
 ---
 ## 5. Updating Content
 - **Website**: Modify components in `app/src/components/` or pages in `app/src/pages/`, and style with Tailwind in `app/src/styles/globals.css`.
-- **CV PDF**: Update `app/src/data/cv.yml` then run from repo root:
+- **CV PDF**: Update `data/cv.yml` then run from repo root:
   ```bash
   ./scripts/generate_cv.py
   ```


### PR DESCRIPTION
## Summary
- point documentation to `data/cv.yml`
- link to RUNBOOK in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843c9063d5c8327b766a9abdcddf28e