### PR TITLE
Validate data/cv.yml at build time with a zod schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,102 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repo. Keep changes scoped — this is a small personal site, not a platform.
+
+## What this is
+
+**frankk.me** — Frank Alvarado's personal CV / portfolio. A statically-exported Next.js site whose content comes entirely from a single YAML file. Same YAML also feeds a LaTeX-rendered PDF resume.
+
+For background, see [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md), [RUNBOOK.md](RUNBOOK.md), [SECURITY.md](SECURITY.md).
+
+## Repo layout
+
+| Path | Purpose |
+| --- | --- |
+| [app/](app/) | Next.js 16 app (React 19, Tailwind 3, Jest). Static export. |
+| [data/cv.yml](data/cv.yml) | **Source of truth** for all CV content. Edit here, not in components. |
+| [scripts/generate_cv.py](scripts/generate_cv.py) | Renders LaTeX → `app/public/cv.pdf` from `data/cv.yml`. |
+| [latex/](latex/) | LaTeX templates / assets for the PDF. |
+| [infrastructure/](infrastructure/) | Terraform: S3, CloudFront, ACM, Cloudflare DNS. |
+| [.github/workflows/](.github/workflows/) | CI/CD pipeline (test → infra → deploy → tag). |
+
+## Key files
+
+- [app/src/pages/index.jsx](app/src/pages/index.jsx) — entry page; reads + validates `data/cv.yml` via `getStaticProps`.
+- [app/src/pages/_app.jsx](app/src/pages/_app.jsx) — wraps pages with `ThemeToggle` + GA script.
+- [app/src/components/](app/src/components/) — `Profile`, `Experience`, `Education`, `Skills`, `ThemeToggle`.
+- [app/src/lib/cv-schema.js](app/src/lib/cv-schema.js) — zod schema for `cv.yml`. Build fails if YAML drifts from this.
+- [app/src/instrumentation-client.js](app/src/instrumentation-client.js) — Sentry client init (replay, console logs, custom metrics).
+- [infrastructure/main.tf](infrastructure/main.tf) — S3 + CloudFront + ACM + Cloudflare records.
+- [.github/workflows/ci-cd.yml](.github/workflows/ci-cd.yml) — test, terraform apply, build/deploy, auto-tag release.
+
+## Where tests live
+
+[app/src/__tests__/](app/src/__tests__/) — Jest + RTL. One test file per component/page/lib. Shared helpers in [app/src/__tests__/utils/](app/src/__tests__/utils/) (excluded from test discovery via `testPathIgnorePatterns`).
+
+## Adding a new CV section
+
+1. Add the new section to [data/cv.yml](data/cv.yml).
+2. Extend the zod schema in [app/src/lib/cv-schema.js](app/src/lib/cv-schema.js) so the build doesn't reject it.
+3. Create a presentation component under [app/src/components/](app/src/components/) — it should accept the section data as a prop and render only.
+4. Mount it in [app/src/pages/index.jsx](app/src/pages/index.jsx) inside `<main>` and destructure the prop from `Home(...)`.
+5. Add a test under [app/src/__tests__/components/](app/src/__tests__/components/) mirroring the existing component-test pattern.
+
+## Paths to ignore
+
+When grepping/exploring, skip these — they're build output, vendored code, or LaTeX artifacts:
+
+- `app/.next/`, `app/out/`, `app/coverage/` — Next build / static export / Jest coverage
+- `app/node_modules/` — dependencies
+- `latex/**/*.{aux,log,out,toc,fdb_latexmk,fls,synctex.gz}` — LaTeX intermediate files
+- `infrastructure/.terraform/`, `infrastructure/*.tfstate*` — Terraform state and providers
+
+## Common commands
+
+```bash
+# Dev / build / test (run from app/)
+cd app
+npm install
+npm run dev          # localhost:3000
+npm run build        # static export → app/out/
+npm test             # Jest + RTL with coverage
+npm run test:ci      # CI: JSON + LCOV coverage reporters
+npm run analyze      # bundle analysis
+
+# Regenerate the PDF CV (run from repo root)
+./scripts/generate_cv.py    # requires python3 + pyyaml + pdflatex
+
+# Infrastructure (from infrastructure/)
+terraform init -backend-config=...
+terraform apply
+```
+
+Node ≥ 20.9 (CI uses Node 22).
+
+## Tech stack
+
+Next.js 16 (static export, no SSR/API routes), React 19, Tailwind 3 (`darkMode: 'class'`), Jest + React Testing Library (jsdom), js-yaml, Sentry (`@sentry/nextjs` + `@sentry/profiling-node`), Google Analytics 4, Terraform 1.5, AWS (S3 + CloudFront + ACM via OIDC), Cloudflare DNS, Codecov.
+
+## Conventions
+
+- **JSX only** — no TypeScript. Don't introduce `.ts`/`.tsx` without asking. For type hints, use JSDoc against the zod-inferred `Cv` type from [cv-schema.js](app/src/lib/cv-schema.js): `/** @type {import('../lib/cv-schema').Cv} */`.
+- **CV content lives in [data/cv.yml](data/cv.yml)** — to update profile/experience/skills, edit the YAML, not the React components. Components are presentation only. The shape is enforced by zod at build time — see [Adding a new CV section](#adding-a-new-cv-section).
+- **Dark mode** is class-based (`darkMode: 'class'` in Tailwind) and persisted in `localStorage` by [ThemeToggle](app/src/components/ThemeToggle.jsx).
+- **Coverage threshold is 10%** by design (early-stage). Raise it deliberately, not incidentally.
+- No ESLint/Prettier config is checked in — defer to Next.js defaults.
+
+## Gotchas (read before editing)
+
+- **Static export only.** `next build` produces `app/out/`. There are no API routes, no SSR, no `getServerSideProps`. New data must come through `getStaticProps` at build time, or be loaded client-side.
+- **`app/public/cv.pdf` is not built by CI.** After editing `data/cv.yml`, run `./scripts/generate_cv.py` locally and commit the regenerated PDF — otherwise the downloadable CV drifts from the site.
+- **AWS uses OIDC in CI** — there are no long-lived AWS access keys, and there shouldn't be. Don't add `AWS_ACCESS_KEY_ID`-style secrets; extend the OIDC role instead.
+- **Sentry DSN and GA ID** are injected at build time via `NEXT_PUBLIC_SENTRY_DSN` and `NEXT_PUBLIC_GOOGLE_ANALYTICS_ID`. Missing values won't fail the build but will silently disable telemetry.
+- **CI auto-tags releases** as `YYYY-MM-DD-SHA` after a successful deploy on `main`. Don't create release tags manually.
+- **Deploy is fire-and-forget on `main`**: a merged PR triggers terraform apply + S3 sync + CloudFront invalidation. Treat `main` accordingly.
+
+## External integrations
+
+- **Sentry** — errors, session replay (10% sampled / 100% on error), Node profiling, custom metrics (`user_action`, `api_response_time`).
+- **Google Analytics 4** — loaded via `<Script strategy="afterInteractive">` in `_app.jsx`.
+- **Codecov** — coverage uploaded from CI.
+- **AWS** — S3 bucket (private, OAI-fronted) + CloudFront + ACM.
+- **Cloudflare** — DNS only; ACM validation records managed via Terraform.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -13,7 +13,8 @@
         "js-yaml": "^4.1.1",
         "next": "^16.2.6",
         "react": "^19.2.4",
-        "react-dom": "^19.2.4"
+        "react-dom": "^19.2.4",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",
@@ -11140,6 +11141,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,8 @@
     "js-yaml": "^4.1.1",
     "next": "^16.2.6",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/app/src/__tests__/lib/cv-schema.test.js
+++ b/app/src/__tests__/lib/cv-schema.test.js
@@ -1,0 +1,63 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import { CvSchema, parseCv } from '../../lib/cv-schema';
+
+const validCv = {
+  profile: {
+    name: { first: 'Frank', last: 'Alvarado' },
+    title: 'Software Engineer',
+    location: 'Houston, TX',
+    contact: {
+      email: 'test@example.com',
+      website: 'https://frankk.me',
+      github: 'https://github.com/frank-alvarado',
+      linkedin: 'https://www.linkedin.com/in/fralvarado',
+    },
+  },
+  experiences: [
+    {
+      title: 'Senior Software Engineer',
+      company: 'Acme',
+      location: 'Houston, TX',
+      period: '2020 - PRESENT',
+      details: ['Did stuff'],
+    },
+  ],
+  education: [
+    {
+      degree: 'B.S.',
+      school: 'UT Austin',
+      location: 'Austin, TX',
+      time: '2009 - 2013',
+    },
+  ],
+  skills: { proficient: ['Java'], familiar: ['Python'], tools: ['Git'] },
+};
+
+describe('CvSchema', () => {
+  it('accepts a well-formed CV payload', () => {
+    expect(() => CvSchema.parse(validCv)).not.toThrow();
+  });
+
+  it('parseCv throws a readable error for invalid email', () => {
+    const bad = { ...validCv, profile: { ...validCv.profile, contact: { ...validCv.profile.contact, email: 'not-an-email' } } };
+    expect(() => parseCv(bad)).toThrow(/profile\.contact\.email/);
+  });
+
+  it('parseCv throws when a required field is missing', () => {
+    const bad = { ...validCv, profile: { ...validCv.profile, title: undefined } };
+    expect(() => parseCv(bad)).toThrow(/profile\.title/);
+  });
+
+  it('parseCv requires at least one experience and one education entry', () => {
+    expect(() => parseCv({ ...validCv, experiences: [] })).toThrow(/experiences/);
+    expect(() => parseCv({ ...validCv, education: [] })).toThrow(/education/);
+  });
+
+  it('validates the actual data/cv.yml file', () => {
+    const cvPath = path.join(process.cwd(), '..', 'data', 'cv.yml');
+    const raw = yaml.load(fs.readFileSync(cvPath, 'utf8'));
+    expect(() => CvSchema.parse(raw)).not.toThrow();
+  });
+});

--- a/app/src/__tests__/pages/index.test.jsx
+++ b/app/src/__tests__/pages/index.test.jsx
@@ -67,16 +67,41 @@ describe('Home Page', () => {
 });
 
 describe('getStaticProps', () => {
-  it('reads cv.yml and returns parsed props', async () => {
-    const mockCv = {
-      profile: { name: 'Test User' },
-      experiences: [{ title: 'Dev' }],
-      education: [{ degree: 'CS' }],
-      skills: { languages: ['JS'] },
-    };
+  const validCv = {
+    profile: {
+      name: { first: 'Test', last: 'User' },
+      title: 'Software Engineer',
+      location: 'Houston, TX',
+      contact: {
+        email: 'test@example.com',
+        website: 'https://example.com',
+        github: 'https://github.com/test',
+        linkedin: 'https://www.linkedin.com/in/test',
+      },
+    },
+    experiences: [
+      {
+        title: 'Dev',
+        company: 'Acme',
+        location: 'Houston, TX',
+        period: '2020 - PRESENT',
+        details: ['Did stuff'],
+      },
+    ],
+    education: [
+      {
+        degree: 'B.S.',
+        school: 'University',
+        location: 'Austin, TX',
+        time: '2016 - 2020',
+      },
+    ],
+    skills: { proficient: ['JS'], tools: ['Git'] },
+  };
 
+  it('reads cv.yml and returns parsed props', async () => {
     jest.spyOn(fs, 'readFileSync').mockReturnValue('mocked yaml');
-    jest.spyOn(yaml, 'load').mockReturnValue(mockCv);
+    jest.spyOn(yaml, 'load').mockReturnValue(validCv);
 
     const result = await getStaticProps();
 
@@ -85,7 +110,17 @@ describe('getStaticProps', () => {
       'utf8'
     );
     expect(yaml.load).toHaveBeenCalledWith('mocked yaml');
-    expect(result).toEqual({ props: mockCv });
+    expect(result).toEqual({ props: validCv });
+
+    fs.readFileSync.mockRestore();
+    yaml.load.mockRestore();
+  });
+
+  it('throws a readable error when cv.yml fails schema validation', async () => {
+    jest.spyOn(fs, 'readFileSync').mockReturnValue('mocked yaml');
+    jest.spyOn(yaml, 'load').mockReturnValue({ profile: { name: 'broken' } });
+
+    await expect(getStaticProps()).rejects.toThrow(/Invalid data\/cv\.yml/);
 
     fs.readFileSync.mockRestore();
     yaml.load.mockRestore();

--- a/app/src/lib/cv-schema.js
+++ b/app/src/lib/cv-schema.js
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+
+const ContactSchema = z.object({
+  email: z.string().email(),
+  website: z.string().url(),
+  github: z.string().url(),
+  linkedin: z.string().url(),
+});
+
+const ProfileSchema = z.object({
+  name: z.object({
+    first: z.string().min(1),
+    last: z.string().min(1),
+  }),
+  title: z.string().min(1),
+  location: z.string().min(1),
+  contact: ContactSchema,
+});
+
+const ExperienceSchema = z.object({
+  title: z.string().min(1),
+  company: z.string().min(1),
+  location: z.string().min(1),
+  period: z.string().min(1),
+  details: z.array(z.string().min(1)).min(1),
+});
+
+const EducationSchema = z.object({
+  degree: z.string().min(1),
+  school: z.string().min(1),
+  location: z.string().min(1),
+  time: z.string().min(1),
+  image: z.string().optional(),
+});
+
+const SkillsSchema = z.object({
+  proficient: z.array(z.string().min(1)).optional(),
+  familiar: z.array(z.string().min(1)).optional(),
+  tools: z.array(z.string().min(1)).optional(),
+});
+
+export const CvSchema = z.object({
+  profile: ProfileSchema,
+  experiences: z.array(ExperienceSchema).min(1),
+  education: z.array(EducationSchema).min(1),
+  skills: SkillsSchema,
+});
+
+/**
+ * Parsed and validated CV payload. Use this type in JSDoc annotations
+ * to get editor type hints when working with cv.yml data.
+ *
+ * @typedef {z.infer<typeof CvSchema>} Cv
+ */
+
+export function parseCv(raw) {
+  const result = CvSchema.safeParse(raw);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `  - ${i.path.join('.') || '(root)'}: ${i.message}`)
+      .join('\n');
+    throw new Error(`Invalid data/cv.yml — schema validation failed:\n${issues}`);
+  }
+  return result.data;
+}

--- a/app/src/pages/index.jsx
+++ b/app/src/pages/index.jsx
@@ -6,6 +6,7 @@ import Profile from '../components/Profile'
 import Experience from '../components/Experience'
 import Education from '../components/Education'
 import Skills from '../components/Skills'
+import { parseCv } from '../lib/cv-schema'
 
 export default function Home({ profile, experiences, education, skills }) {
   return (
@@ -30,6 +31,6 @@ export default function Home({ profile, experiences, education, skills }) {
 export async function getStaticProps() {
   const filePath = path.join(process.cwd(), '..', 'data', 'cv.yml')
   const fileContents = fs.readFileSync(filePath, 'utf8')
-  const cv = yaml.load(fileContents)
+  const cv = parseCv(yaml.load(fileContents))
   return { props: cv }
 }


### PR DESCRIPTION
## Summary

- Introduces a single zod schema in [app/src/lib/cv-schema.js](app/src/lib/cv-schema.js) that describes every field of `data/cv.yml` (profile, experiences, education, skills) plus URL/email format checks.
- Wires `parseCv()` into `getStaticProps` in [app/src/pages/index.jsx](app/src/pages/index.jsx) — a typo, missing field, or invalid contact URL now fails `next build` with a readable, path-pointed error instead of rendering a broken page.
- Exports an inferred `Cv` JSDoc typedef so component props can be type-hinted in editors without adopting TypeScript.
- Adds [CLAUDE.md](CLAUDE.md) at the repo root: orientation, commands, conventions, and gotchas for Claude Code sessions. Documents the new "add a CV section" workflow (edit YAML → extend schema → component → mount → test).

## Why

The CV data is the entire content layer for both the site and the PDF. Before this change, breaking it produced either a crashing render or a silently empty section — both of which would have shipped through CI. Validation moves that failure to the build step.

## Test plan

- [x] `npm install` (adds zod ^3.23.8)
- [x] `npm test` — 37 tests pass, 100% statement coverage. New tests in [app/src/__tests__/lib/cv-schema.test.js](app/src/__tests__/lib/cv-schema.test.js) cover happy path, invalid email, missing field, empty arrays, and the actual `data/cv.yml`.
- [x] `npm run build` — static export succeeds; `/` is prerendered via SSG, proving the live `data/cv.yml` passes the schema.
- [ ] CI green on this PR

## Stacked PRs

This is **PR 1 of 3** in a stack:
1. **This PR** — schema validation + CLAUDE.md
2. SEO meta tags + Lighthouse CI + axe-core a11y tests
3. ESLint + Prettier + husky/lint-staged + coverage bump + PDF-in-CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)